### PR TITLE
Include Homebrew's PG include path

### DIFF
--- a/generate_bindings.sh
+++ b/generate_bindings.sh
@@ -9,7 +9,8 @@ echo '#include "replication/output_plugin.h"' >> /tmp/postgres.c
 echo '#include "replication/logical.h"' >> /tmp/postgres.c
 
 
-gcc -I /usr/include/postgresql/9.4/server -E /tmp/postgres.c > /tmp/libpq.c
+gcc -I /usr/include/postgresql/9.4/server -I /usr/local/include/server/ \
+    -E /tmp/postgres.c > /tmp/libpq.c
 
 cat /tmp/libpq.c | python src/remove_duplicate_single_line_statements.py  > /tmp/libpq_dedup.c
 


### PR DESCRIPTION
This is for Mac.

I get an error (`dyld: Library not loaded: @rpath/libclang.dylib`) but this is obviously an issue with my local setup:

```
:;  ./generate_bindings.sh 
+ which bindgen
/Users/solidsnack/.cargo/bin/bindgen
+ echo '#include <stdarg.h>'
+ echo '#include "postgres.h"'
+ echo '#include "fmgr.h"'
+ echo '#include "replication/output_plugin.h"'
+ echo '#include "replication/logical.h"'
+ gcc -I '/usr/include/postgresql/9.*/server' -I /usr/local/include/server/ -E /tmp/postgres.c
+ cat /tmp/libpq.c
+ python src/remove_duplicate_single_line_statements.py
+ bindgen -allow-bitfields -builtins /tmp/libpq_dedup.c
dyld: Library not loaded: @rpath/libclang.dylib
  Referenced from: /Users/solidsnack/.cargo/bin/bindgen
  Reason: image not found
./generate_bindings.sh: line 16:  2019 Trace/BPT trap: 5       bindgen -allow-bitfields -builtins /tmp/libpq_dedup.c > src/libpq.rs
```

Assuming we merge this in with the Mac paths I think we're good to go. We should set aside time later to make generation of `libpq.rs` the default -- part of the `build.rs` -- but there's no urgency in that now.
