### PR TITLE
[WIP] Special linker args and text formatting

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -49,7 +49,6 @@ fn main() {
                 .include(config.includedir)
                 .include(config.includedir_server)
                 .compile("libmagic.a");
-    println!("cargo:rustc-link-search={}", config.libdir);
-    println!("cargo:rustc-link-lib=pgcommon");
-    println!("cargo:rustc-link-lib=pgport");
+    // println!("cargo:more-args-somehow={}",
+    //          "-C link-args='-Wl,-undefined,dynamic_lookup'");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 extern crate libc;
+use std::ffi::CString;
 
 #[allow(dead_code,
         non_snake_case,
@@ -49,7 +50,13 @@ pub type LogicalDecodeStartupCB =
 
 extern fn begin(ctx: *mut libpq::Struct_LogicalDecodingContext,
                 txn: *mut libpq::ReorderBufferTXN) {
-
+    unsafe {
+        let last = 1;                                     // True in C language
+        let s = CString::new("BEGIN %u").unwrap();
+        libpq::OutputPluginPrepareWrite(ctx, last);
+        libpq::appendStringInfo((*ctx).out, s.as_ptr(), (*txn).xid);
+        libpq::OutputPluginWrite(ctx, last);
+    }
 }
 /*
 pub type LogicalDecodeBeginCB =
@@ -77,7 +84,13 @@ pub type LogicalDecodeChangeCB =
 extern fn commit(ctx: *mut libpq::Struct_LogicalDecodingContext,
                  txn: *mut libpq::ReorderBufferTXN,
                  lsn: libpq::XLogRecPtr) {
-
+    unsafe {
+        let last = 1;                                     // True in C language
+        let s = CString::new("COMMIT %u").unwrap();
+        libpq::OutputPluginPrepareWrite(ctx, last);
+        libpq::appendStringInfo((*ctx).out, s.as_ptr(), (*txn).xid);
+        libpq::OutputPluginWrite(ctx, last);
+    }
 }
 /*
 pub type LogicalDecodeCommitCB =

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,9 @@ pub type LogicalOutputPluginInit =
 extern fn startup(ctx: *mut libpq::Struct_LogicalDecodingContext,
                   options: *mut libpq::OutputPluginOptions,
                   is_init: libpq::_bool) {
-
+    unsafe {
+        (*options).output_type = libpq::OUTPUT_PLUGIN_TEXTUAL_OUTPUT;
+    }
 }
 /*
 pub type LogicalDecodeStartupCB =


### PR DESCRIPTION
This is actually printing the right stuff in Postgres.

On Mac, we need to pass flags to the linker. Rust has `-C, --codegen` for this purpose. You pass the options like this: `-C link-args='-Wl,-undefined,dynamic_lookup'`.

```
rustc src/lib.rs --crate-name elephantpump --crate-type rlib --crate-type dylib -g --out-dir /Users/solidsnack/sandbox/elephantpump/target/debug --emit=dep-info,link -C link-args='-Wl,-undefined,dynamic_lookup' -L dependency=/Users/solidsnack/sandbox/elephantpump/target/debug -L dependency=/Users/solidsnack/sandbox/elephantpump/target/debug/deps --extern libc=/Users/solidsnack/sandbox/elephantpump/target/debug/deps/liblibc-adb8b8e7aaa2f93f.rlib -L native=/Users/solidsnack/sandbox/elephantpump/target/debug/build/elephantpump-b9e70626c3c6fc87/out -l static=magic
```

I am not sure how to actually pass flags like this from `build.rs`. So they are in there but commented out.

You can run a build with `cargo build -v` and then copy paste the failing final command, adding the linker args as above.

Once you have it built, `libelephant.dylib` can be treated by Postgres as a logical output decoder.

``` sql
--# solidsnack@[local]/~ 
SELECT pg_create_logical_replication_slot('elf', '/path/to/libelephantpump.dylib');
 pg_create_logical_replication_slot
────────────────────────────────────
 (elf,0/AB2B6D0)
(1 row)

Time: 14.244 ms
--# solidsnack@[local]/~ 
SELECT * FROM pg_logical_slot_get_changes('elf', NULL, NULL);
 location │ xid │ data
──────────┼─────┼──────
(0 rows)

Time: 1.573 ms
--# solidsnack@[local]/~ 
INSERT INTO tmp (i) VALUES (2);
INSERT 0 1
Time: 2.599 ms
--# solidsnack@[local]/~ 
SELECT * FROM pg_logical_slot_get_changes('elf', NULL, NULL);
 location  │ xid  │    data
───────────┼──────┼─────────────
 0/AB2B708 │ 1739 │ BEGIN 1739
 0/AB2B878 │ 1739 │ COMMIT 1739
(2 rows)

Time: 7.947 ms
```
