### PR TITLE
Call out to `row_to_json` for serialization

### DIFF
--- a/fixture.sql
+++ b/fixture.sql
@@ -1,0 +1,14 @@
+SELECT * FROM pg_drop_replication_slot('jsoncdc');
+SELECT * FROM pg_create_logical_replication_slot('jsoncdc', 'jsoncdc');
+BEGIN;
+CREATE SCHEMA IF NOT EXISTS jsoncdc;
+CREATE TABLE IF NOT EXISTS jsoncdc.test (
+  i   integer NOT NULL,
+  t   timestamptz NOT NULL DEFAULT NOW(),
+  h   hstore NOT NULL DEFAULT ''
+);
+INSERT INTO jsoncdc.test (i, h) VALUES (7, 'a => 7');
+INSERT INTO jsoncdc.test (i, h) VALUES (9, 'a => 9');
+END;
+SELECT * FROM pg_logical_slot_get_changes('jsoncdc', NULL, NULL);
+SELECT * FROM pg_drop_replication_slot('jsoncdc');

--- a/src/libpq.rs
+++ b/src/libpq.rs
@@ -8666,7 +8666,7 @@ extern "C" {
     pub static mut PortalContext: MemoryContext;
 }
 extern "C" {
-    pub static mut row_to_json: PGFunction;
+    pub fn row_to_json(fcinfo: FunctionCallInfo) -> Datum;
 }
 extern "C" {
     pub fn ffsl(arg1: ::libc::c_long) -> ::libc::c_int;

--- a/src/libpq.rs
+++ b/src/libpq.rs
@@ -8666,9 +8666,7 @@ extern "C" {
     pub static mut PortalContext: MemoryContext;
 }
 extern "C" {
-    pub fn composite_to_json(composite: Datum,
-                             result: StringInfo,
-                             use_line_feeds: _bool);
+    pub static mut row_to_json: PGFunction;
 }
 extern "C" {
     pub fn ffsl(arg1: ::libc::c_long) -> ::libc::c_int;


### PR DESCRIPTION
This is just for progress tracking and discussion; not really mergeable.

```
STATEMENT:  SELECT * FROM pg_logical_slot_get_changes('jsoncdc', NULL, NULL);
LOG:  server process (PID 26064) was terminated by signal 11: Segmentation fault
DETAIL:  Failed process was running: SELECT * FROM pg_logical_slot_get_changes('jsoncdc', NULL, NULL);
```
