### PR TITLE
Rely on text internals to render `json`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,8 +106,8 @@ unsafe fn append_tuple_buf_as_json(data: *mut libpq::ReorderBufferTupleBuf,
         let json = libpq::DirectFunctionCall1Coll(Some(row_to_json),
                                                   empty_oid,
                                                   datum);
-        let json_output_function: libpq::Oid = 322;     // TODO: Dynamic lookup
-        let text = libpq::OidOutputFunctionCall(json_output_function, json);
+        let ptr = json as *const libpq::Struct_varlena;
+        let text = libpq::text_to_cstring(ptr);
         libpq::appendStringInfoString(out, text);
     } else {
         append("{}", out);

--- a/test/sql/bigdata.sql
+++ b/test/sql/bigdata.sql
@@ -1,0 +1,45 @@
+\set ECHO none
+SET client_min_messages TO error;
+\t on
+\x off
+SELECT 'created logical replication slot'
+  FROM pg_create_logical_replication_slot('jsoncdc', 'jsoncdc');
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS jsoncdc;
+SET LOCAL search_path TO jsoncdc, public;
+CREATE EXTENSION IF NOT EXISTS hstore;
+
+CREATE TABLE IF NOT EXISTS test (
+  i   integer PRIMARY KEY,
+  h   hstore NOT NULL DEFAULT ''
+);
+
+INSERT INTO test (i) SELECT i FROM generate_series(1, 1024) AS i;
+
+CREATE VIEW changedata AS
+SELECT data FROM pg_logical_slot_get_changes('jsoncdc', NULL, NULL);
+
+END;
+
+BEGIN;
+SET LOCAL search_path TO jsoncdc, public;
+UPDATE test SET h = hstore('i', i::text)
+                 || hstore((SELECT array_agg(n::text)
+                              FROM generate_series(1, i) AS n),
+                           (SELECT array_agg(n::text)
+                              FROM generate_series(1, i) AS n));
+DELETE FROM test WHERE i % 2 = 1;
+END;
+
+--- Displays only generated JSON, no replication slot metadata, and omits
+--- transaction IDs (which would confuse the testing framework because they
+--- vary from run to run).
+SELECT * FROM jsoncdc.changedata
+ WHERE NOT (data LIKE '{ "begin": %' OR data LIKE '{ "commit": %');
+
+SELECT 'deleted logical replication slot'
+  FROM pg_drop_replication_slot('jsoncdc');
+
+DROP SCHEMA jsoncdc CASCADE;


### PR DESCRIPTION
The output function lookup will be very hard because I am not sure how even to
find the type OID for `json` (not sure how to get a type from a Datum).

Under the hood, `json` (but not `jsonb`) is text. You can see one consequence
of this in the bodies of [`textout`](http://doxygen.postgresql.org/varlena_8c_source.html#l00520) and [`json_out`](http://doxygen.postgresql.org/json_8c_source.html#l00245):

``` c
Datum
textout(PG_FUNCTION_ARGS)
{
    Datum       txt = PG_GETARG_DATUM(0);

    PG_RETURN_CSTRING(TextDatumGetCString(txt));
}

Datum
json_out(PG_FUNCTION_ARGS)
{
    /* we needn't detoast because text_to_cstring will handle that */
    Datum       txt = PG_GETARG_DATUM(0);

    PG_RETURN_CSTRING(TextDatumGetCString(txt));
}
```

They are the same function. Clicking through the macros we get a cast and then
the conversion to a CString with `text_to_cstring`. So we don't need an ouput
function after all.
