### PR TITLE
Fix packaging issue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "jsoncdc"
-version = "0.0.6"
+version = "0.0.7"
 authors = ["Alex Newman <posi@planet.com>",
            "Jason Dusek <jason.dusek@gmail.com>"]
 build = "build.rs"

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
     "name": "jsoncdc",
     "abstract": "Translates Postgres WAL to JSON",
     "description": "A Rust plugin for Postgres Change Data Control.",
-    "version": "0.0.6",
+    "version": "0.0.7",
     "maintainer": [
         "Alex Newman <posi@planet.com>",
         "Jason Dusek <jason.dusek@gmail.com>"
@@ -16,7 +16,7 @@
             "abstract": "Translates Postgres WAL to JSON",
             "file": "sql/jsoncdc.sql",
             "docfile": "doc/jsoncdc.md",
-            "version": "0.0.6"
+            "version": "0.0.7"
         }
     },
     "release_status": "unstable",

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,6 @@ all: sql/$(EXTENSION)--$(EXTVERSION).sql
 sql/$(EXTENSION)--$(EXTVERSION).sql: sql/$(EXTENSION).sql
 	cp $< $@
 
-DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
 EXTRA_CLEAN = sql/$(EXTENSION)--$(EXTVERSION).sql
 endif
 

--- a/jsoncdc.control
+++ b/jsoncdc.control
@@ -1,5 +1,5 @@
 # jsoncdc extension
 comment = 'JSON Logical Decoding'
-default_version = '0.0.6'
+default_version = '0.0.7'
 module_pathname = '$libdir/jsoncdc'
 relocatable = true


### PR DESCRIPTION
Relates to point (4) listed here: http://blog.pgaddict.com/posts/why-pgxn-distribution-tests-fail

> # #​4 - will not overwrite just-created file (11%)
> 
> This seems to be a quite simple problem. In short, it fails like this:
> 
> ```
> INFO: installing extension
> /bin/mkdir -p '/var/pgxn-tester/hudzen-10/pg/9.3.4/share/postgresql/extension'
> /bin/mkdir -p '/var/pgxn-tester/hudzen-10/pg/9.3.4/share/postgresql/extension'
> /bin/mkdir -p '/var/pgxn-tester/hudzen-10/pg/9.3.4/share/doc/postgresql/extension'
> /usr/bin/install -c -m 644 ./pair.control '/var/pg/9.3.4/share/postgresql/extension/'
> /usr/bin/install -c -m 644 ./sql/pair--0.1.2.sql ./sql/pair--unpackaged--0.1.2.sql \
>     ./sql/pair--0.1.2.sql  '/var/pg/9.3.4/share/postgresql/extension/'
> /usr/bin/install: will not overwrite just-created \
>     `/var/pg/9.3.4/share/postgresql/extension/pair--0.1.2.sql' with `./sql/pair--0.1.2.sql'
> gmake: *** [install] Error 1
> ```
> 
> See pg_statsd, pair or json_accessors for a complete log. The cause seems to
> be fairly trivial - caused by this Makefile line:
> 
> ```
> DATA = $(wildcard sql/*--*.sql) sql/$(EXTENSION)--$(EXTVERSION).sql
> ```
> 
> which evaluates into the same filename twice (and /usr/bin/install refuses
> to overwrite the first instance of the file). Fix is as simple as removing
> this particular line from the Makefile.
