### PR TITLE
Test text escaping

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,9 +122,8 @@ unsafe fn append_tuple_buf_as_json(data: *mut pg::ReorderBufferTupleBuf,
         let heap_tuple = &mut (*data).tuple;
         let datum = pg::heap_copy_tuple_as_datum(heap_tuple, desc);
         let empty_oid: pg::Oid = 0;
-        let json = pg::DirectFunctionCall1Coll(Some(row_to_json),
-                                               empty_oid,
-                                               datum);
+        let json =
+            pg::DirectFunctionCall1Coll(Some(row_to_json), empty_oid, datum);
         let ptr = json as *const pg::Struct_varlena;
         let text = pg::text_to_cstring(ptr);
         pg::appendStringInfoString(out, text);

--- a/test/expected/text.out
+++ b/test/expected/text.out
@@ -1,0 +1,11 @@
+\set ECHO none
+ created logical replication slot
+
+ { "table": "jsoncdc.test", "schema": [{"i":"integer"},{"s":"text"}] }
+ { "insert": {"i":1,"s":"simple text"} }
+ { "insert": {"i":2,"s":"text with \"quoted\" text"} }
+ { "insert": {"i":3,"s":"newlines\nand\r\ncarriage returns"} }
+ { "insert": {"i":4,"s":"quoted text with\n\"newline\""} }
+
+ deleted logical replication slot
+

--- a/test/sql/text.sql
+++ b/test/sql/text.sql
@@ -1,0 +1,40 @@
+
+\set ECHO none
+SET client_min_messages TO error;
+\t on
+\x off
+SELECT 'created logical replication slot'
+  FROM pg_create_logical_replication_slot('jsoncdc', 'jsoncdc');
+
+BEGIN;
+
+CREATE SCHEMA IF NOT EXISTS jsoncdc;
+SET LOCAL search_path TO jsoncdc, public;
+CREATE EXTENSION IF NOT EXISTS hstore;
+
+CREATE TABLE IF NOT EXISTS test (
+  i   integer PRIMARY KEY,
+  s   text NOT NULL DEFAULT ''
+);
+
+INSERT INTO test
+VALUES (1, 'simple text'),
+       (2, E'text with "quoted" text'),
+       (3, E'newlines\nand\r\ncarriage returns'),
+       (4, E'quoted text with\n"newline"');
+
+CREATE VIEW changedata AS
+SELECT data FROM pg_logical_slot_get_changes('jsoncdc', NULL, NULL);
+
+END;
+
+--- Displays only generated JSON, no replication slot metadata, and omits
+--- transaction IDs (which would confuse the testing framework because they
+--- vary from run to run).
+SELECT * FROM jsoncdc.changedata
+ WHERE NOT (data LIKE '{ "begin": %' OR data LIKE '{ "commit": %');
+
+SELECT 'deleted logical replication slot'
+  FROM pg_drop_replication_slot('jsoncdc');
+
+DROP SCHEMA jsoncdc CASCADE;


### PR DESCRIPTION
To get a feel for the rightness of this, we can use JQ:

``` bash
:;  cat results/text.out | fgrep '{' |
    jq -r '.insert.s // empty | @json, @text'
"simple text"
simple text
"text with \"quoted\" text"
text with "quoted" text
"newlines\nand\r\ncarriage returns"
newlines
and
carriage returns
"quoted text with\n\"newline\""
quoted text with
"newline"
```

JQ gives us a good way to compare JSON input to its textual interpretation. We
can see in the above where it parses and correctly interprets the escaped
quotes and control characters.
