### PR TITLE
Add Dockerfile to speedup development

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,3 +10,33 @@ Please ensure that contributed Bash, SQL, Python and other files all:
 
 2. contain lines no longer than 79 columns.
 
+Using Docker for development
+----------------------------
+
+You can use the project's [Dockerfile](Dockerfile) to get a working development environment.
+
+##### Usage
+
+Build the image locally:
+
+```sh
+docker build -t jsoncdc-dev:9.5 .
+```
+
+Start the container by mapping the source code volume - this should be done on the directory where you've checked out jsoncdc:
+
+```sh
+docker run --rm -it --name jsoncdc -v $(pwd):/src jsoncdc-dev:9.5
+```
+
+Run the test suite on another shell using the `postgres`:
+
+```sh
+docker exec jsoncdc bash -c 'make install && make test PGUSER=postgres'
+```
+
+##### Environment
+
+- Cargo binaries are exposed on the `$PATH`. This means that `make test` will be able to run the `style` script correctly.
+- Postgres does not need any additional manual configuration.
+- The PGXN Client tool (`pgxnclient`) is pre-installed to allow `installcheck` to run correctly.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM postgres:9.5
+
+ENV RUST_VERSION 1.8.0
+ENV PATH ~/.cargo/bin/:$PATH
+
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends ca-certificates curl git make gcc postgresql-server-dev-$PG_MAJOR=$PG_VERSION python-pip \
+  && mkdir -p /tmp/build \
+  && curl -o /tmp/build/rust-${RUST_VERSION}.tar.gz -SL https://static.rust-lang.org/dist/rust-${RUST_VERSION}-x86_64-unknown-linux-gnu.tar.gz \
+  && tar -xzf /tmp/build/rust-${RUST_VERSION}.tar.gz -C /tmp/build/ \
+  && sh /tmp/build/rust-${RUST_VERSION}-x86_64-unknown-linux-gnu/install.sh \
+  && rm -rf /var/lib/apt/lists/* \
+  && pip install pgxnclient \
+  && cargo install rustfmt
+
+WORKDIR /src
+
+VOLUME /src
+
+COPY util/docker /docker-entrypoint-initdb.d/docker.sh

--- a/util/docker
+++ b/util/docker
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+cat <<-EOF >> $PGDATA/postgresql.conf
+max_replication_slots = 1
+max_wal_senders = 1
+wal_level = logical
+EOF
+
+cat <<-EOF >> $PGDATA/pg_hba.conf
+host replication all 0.0.0.0/0 trust
+local replication all trust
+EOF


### PR DESCRIPTION
This PR introduces a Dockerfile that prepares a container for local development. All the necessary tools are installed and the `/src` directory mounted from the host.
##### Features
- Cargo binaries are exposed on the `PATH`. This means that `make test` will run correctly when executing the `style` script.
- Postgres does not need any additional manual configuration.
- `pgxnclient` is added to allow `installcheck` running correctly.
##### Usage

Build the image locally:

``` sh
docker build -t jsoncdc-dev:9.5 .
```

Start the container by mapping the source code volume - this should be done on the directory where you've checked out jsoncdc:

``` sh
docker run --rm -it --name jsoncdc -v $(pwd):/src jsoncdc-dev:9.5
```

Run the test suite using the `postgres` user:

``` sh
docker exec jsoncdc bash -c 'make install && make test PGUSER=postgres'
```
