### PR TITLE
remove panic on unrecognized change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV SRC_PATH /src
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    ca-certificates curl git make gcc postgresql-server-dev-$PG_MAJOR=$PG_VERSION python-pip \
+    ca-certificates curl git make gcc gcc-multilib postgresql-server-dev-$PG_MAJOR=$PG_VERSION python-pip \
   && rm -rf /var/lib/apt/lists/* \
   && curl -sf https://static.rust-lang.org/rustup.sh -o rustup.sh \
   && bash rustup.sh --disable-sudo -y --verbose \

--- a/util/travis
+++ b/util/travis
@@ -38,7 +38,7 @@ function linux {
   HBA_CONF="$PG_DIR"/pg_hba.conf
   CONF="$PG_DIR"/postgresql.conf
 
-  sudo -E env PATH="$PATH" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" make install
+  sudo -E env PATH="$PATH" LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" make install
   sudo pg_ctlcluster "$VERSION" main stop
 
   msg "Setting $HBA_CONF settings..."
@@ -63,7 +63,7 @@ function osx {
   rm -rf "$PG_DIR"
 
   brew update > "$BREW_LOG"
-  brew remove postgresql >> "$BREW_LOG"
+  brew uninstall postgresql --ignore-dependencies >> "$BREW_LOG"
   brew upgrade >> "$BREW_LOG"
 
   make clean all install


### PR DESCRIPTION
tl;dr

panics are super scary, probably don't need to panic just because
we barfed on one change. simply logging it, and returning should
be fine.

---

Motivation:

We were looking through the source of jsoncdc, and had noticed there was
a panic inside `append_change`. We couldn't think of a reason to panic
here (although we don't have as much insight I'm sure). Talking it over
we decided to switch to simply logging the unrecognized change action
instead.

We don't see a problem with replacing this panic (and all of the tests
still pass), however if you want we can change this PR to use a
compile time feature that isn't on by default.

Docker Changes:

I was unable to build the dockerfile when attempting to run tests.
Specifically it failed building `rustfmt`, by adding in gcc-multilib
I was able to build the dockerfile so I've added that into my change too.