### PR TITLE
Merge changes from PR and fix `rustfmt`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ ENV SRC_PATH /src
 
 RUN apt-get update \
   && apt-get install -y --no-install-recommends \
-    ca-certificates curl git make gcc postgresql-server-dev-$PG_MAJOR=$PG_VERSION python-pip \
+    ca-certificates curl git make gcc gcc-multilib postgresql-server-dev-$PG_MAJOR=$PG_VERSION python-pip \
   && rm -rf /var/lib/apt/lists/* \
   && curl -sf https://static.rust-lang.org/rustup.sh -o rustup.sh \
   && bash rustup.sh --disable-sudo -y --verbose \

--- a/build.rs
+++ b/build.rs
@@ -7,14 +7,15 @@ use std::process::Command;
 struct PGConfig {
     includedir: String,
     includedir_server: String,
-    libdir: String
+    libdir: String,
 }
 
 
 fn pg_config() -> PGConfig {
-    let output = Command::new("pg_config").output().unwrap_or_else(|e| {
-        panic!("Failed to execute process: {}", e)
-    });
+    let output =
+        Command::new("pg_config")
+            .output()
+            .unwrap_or_else(|e| panic!("Failed to execute process: {}", e));
     /* Sample result:
         ...
         INCLUDEDIR = /usr/local/Cellar/postgresql/9.4.5/include
@@ -29,13 +30,18 @@ fn pg_config() -> PGConfig {
     let text = String::from_utf8(output.stdout)
                       .expect("Expected UTF-8 from call to `pg_config`.");
 
-    for words in text.lines().map(|line| line.split_whitespace()) {
+    for words in text.lines()
+                     .map(|line| {
+                              line.split_whitespace()
+                          }) {
         let vec: Vec<&str> = words.collect();
         match vec[0] {
-            "INCLUDEDIR"        => config.includedir = vec[2].into(),
-            "INCLUDEDIR-SERVER" => config.includedir_server = vec[2].into(),
-            "LIBDIR"            => config.libdir = vec[2].into(),
-            _                   => {}
+            "INCLUDEDIR" => config.includedir = vec[2].into(),
+            "INCLUDEDIR-SERVER" => {
+                config.includedir_server = vec[2].into()
+            }
+            "LIBDIR" => config.libdir = vec[2].into(),
+            _ => {}
         }
     }
 
@@ -45,9 +51,9 @@ fn pg_config() -> PGConfig {
 fn main() {
     let config = pg_config();
     gcc::Config::new()
-                .file("src/magic.c")
-                .include(config.includedir)
-                .include(config.includedir_server)
-                .compile("libmagic.a");
+        .file("src/magic.c")
+        .include(config.includedir)
+        .include(config.includedir_server)
+        .compile("libmagic.a");
     // The GCC module emits `rustc-link-lib=static=magic` for us.
 }

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,2 +1,13 @@
-ideal_width = 79
-max_width   = 79
+ideal_width            = 79
+max_width              = 79
+
+fn_single_line         = true
+struct_lit_width       = 50
+struct_variant_width   = 50
+
+reorder_imports        = false
+reorder_imported_names = true
+
+chain_base_indent      = 'Visual'
+chain_indent           = 'Visual'
+chains_overflow_last   = false

--- a/util/travis
+++ b/util/travis
@@ -38,7 +38,7 @@ function linux {
   HBA_CONF="$PG_DIR"/pg_hba.conf
   CONF="$PG_DIR"/postgresql.conf
 
-  sudo -E env PATH="$PATH" LD_LIBRARY_PATH="$LD_LIBRARY_PATH" make install
+  sudo -E env PATH="$PATH" LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}" make install
   sudo pg_ctlcluster "$VERSION" main stop
 
   msg "Setting $HBA_CONF settings..."
@@ -63,7 +63,7 @@ function osx {
   rm -rf "$PG_DIR"
 
   brew update > "$BREW_LOG"
-  brew remove postgresql >> "$BREW_LOG"
+  brew uninstall postgresql --ignore-dependencies >> "$BREW_LOG"
   brew upgrade >> "$BREW_LOG"
 
   make clean all install


### PR DESCRIPTION
Fixes a warning in original PR.

Addresses seeming regression or instability in `rustfmt`. Many things changed to be able to pass `checkstyle`. Some things, it seems it just can not format. Filed a bug with them: rust-lang-nursery/rustfmt#1460