### PR TITLE
WIP: Support generic WAL messages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 addons:
-  postgresql: "9.4"
+  postgresql: "9.6"
   apt:
     packages:
     - python-pip

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ sudo: required
 os:
   - linux
   - osx
+services:
+  - postgresql
 addons:
   postgresql: "9.6"
   apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ sudo: required
 os:
   - linux
   - osx
-services:
-  - postgresql
 addons:
   postgresql: "9.6"
   apt:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:9.5
+FROM postgres:9.6
 
 ENV PATH ~/.cargo/bin/:$PATH
 ENV CARGO_HOME /cargo

--- a/README.md
+++ b/README.md
@@ -45,13 +45,15 @@ A basic demo:
     SELECT * FROM pg_logical_slot_get_changes('jsoncdc', NULL, NULL);
 
 The output format of `jsoncdc` is very regular, consisting of `begin`,
-`table`, `insert`, `update` and `delete` clauses as JSON objects, one per line:
+`table`, `insert`, `update`, `delete` and [`message`](https://www.postgresql.org/message-id/flat/56D36A2C.3070807%402ndquadrant.com#56D36A2C.3070807@2ndquadrant.com) clauses as JSON objects, one per line:
 
     { "begin": <xid> }
     { "schema": <column names and type>, "table": <name of table> }
     ...inserts, updates and deletes for this table...
     { "schema": <column names and type>, "table": <name of next table> }
     ...inserts, updates and deletes for next table...
+    { "message": <message>, "prefix": <prefix>, "transactional": <true|false> }
+    ... sent using pg_emit_logical
     { "commit": <xid>, "t": <timestamp with timezone> }
 
 With `pg_recvlogical` and a little shell, you can leverage this very regular

--- a/build.rs
+++ b/build.rs
@@ -12,10 +12,9 @@ struct PGConfig {
 
 
 fn pg_config() -> PGConfig {
-    let output =
-        Command::new("pg_config")
-            .output()
-            .unwrap_or_else(|e| panic!("Failed to execute process: {}", e));
+    let output = Command::new("pg_config").output().unwrap_or_else(|e| {
+        panic!("Failed to execute process: {}", e)
+    });
     /* Sample result:
         ...
         INCLUDEDIR = /usr/local/Cellar/postgresql/9.4.5/include
@@ -27,19 +26,15 @@ fn pg_config() -> PGConfig {
 
     let mut config = PGConfig { ..Default::default() };
 
-    let text = String::from_utf8(output.stdout)
-                      .expect("Expected UTF-8 from call to `pg_config`.");
+    let text = String::from_utf8(output.stdout).expect(
+        "Expected UTF-8 from call to `pg_config`.",
+    );
 
-    for words in text.lines()
-                     .map(|line| {
-                              line.split_whitespace()
-                          }) {
+    for words in text.lines().map(|line| line.split_whitespace()) {
         let vec: Vec<&str> = words.collect();
         match vec[0] {
             "INCLUDEDIR" => config.includedir = vec[2].into(),
-            "INCLUDEDIR-SERVER" => {
-                config.includedir_server = vec[2].into()
-            }
+            "INCLUDEDIR-SERVER" => config.includedir_server = vec[2].into(),
             "LIBDIR" => config.libdir = vec[2].into(),
             _ => {}
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,7 @@ pub unsafe extern "C" fn init(cb: *mut pg::OutputPluginCallbacks) {
     (*cb).change_cb = Some(change);
     (*cb).commit_cb = Some(commit);
     (*cb).shutdown_cb = Some(shutdown);
+    (*cb).message_cb = Some(message);
 }
 
 unsafe extern "C" fn startup(ctx: *mut pg::Struct_LogicalDecodingContext,
@@ -75,6 +76,19 @@ unsafe extern "C" fn shutdown(ctx: *mut pg::Struct_LogicalDecodingContext) {
     pg::pfree((*ctx).output_plugin_private);
 }
 
+#[allow(unused_variables)]
+unsafe extern "C" fn message(ctx: *mut pg::Struct_LogicalDecodingContext,
+                             txn: *mut pg::ReorderBufferTXN,
+                             lsn: pg::XLogRecPtr,
+                             transactional: pg::_bool,
+                             prefix: *const std::os::raw::c_char,
+                             message_size: pg::Size,
+                             message: *const std::os::raw::c_char
+) {
+    pg::OutputPluginPrepareWrite(ctx, CTRUE);
+    append_message(transactional, prefix, message, (*ctx).out);
+    pg::OutputPluginWrite(ctx, CTRUE);
+}
 
 trait PGAppend<T> {
     unsafe fn add_str(self, T);
@@ -95,6 +109,13 @@ impl PGAppend<*mut i8> for pg::StringInfo {
         pg::appendStringInfoString(self, t);
     }
     unsafe fn add_json(self, t: *mut i8) { pg::escape_json(self, t); }
+}
+
+impl PGAppend<*const i8> for pg::StringInfo {
+    unsafe fn add_str(self, t: *const i8) {
+        pg::appendStringInfoString(self, t);
+    }
+    unsafe fn add_json(self, t: *const i8) { pg::escape_json(self, t); }
 }
 
 struct Wrapped(pg::Enum_ReorderBufferChangeType);
@@ -267,6 +288,37 @@ unsafe fn append_schema(relation: pg::Relation, out: pg::StringInfo) {
     out.add_json("table");
     out.add_str(": ");
     out.add_json(qualified_name);
+    out.add_str(" }");
+}
+
+unsafe fn append_message(transactional: pg::_bool,
+                         prefix: *const std::os::raw::c_char,
+                         message: *const std::os::raw::c_char,
+                         out: pg::StringInfo) {
+
+    // { "message": %s, 
+    out.add_str("{ ");
+    out.add_json("message");
+    out.add_str(": ");
+    out.add_json(message);
+    out.add_str(", ");
+
+    // "prefix": %s, 
+    out.add_json("prefix");
+    out.add_str(": ");
+    out.add_json(prefix);
+    out.add_str(", ");
+
+    // "transactional": %s }
+    out.add_json("transactional");
+    out.add_str(": ");
+    
+    if transactional == CTRUE {
+        out.add_str("true");
+    } else {
+        out.add_str("false");
+    }
+
     out.add_str(" }");
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,30 +24,36 @@ pub unsafe extern "C" fn init(cb: *mut pg::OutputPluginCallbacks) {
     (*cb).message_cb = Some(message);
 }
 
-unsafe extern "C" fn startup(ctx: *mut pg::Struct_LogicalDecodingContext,
-                             options: *mut pg::OutputPluginOptions,
-                             _is_init: pg::_bool) {
+unsafe extern "C" fn startup(
+    ctx: *mut pg::Struct_LogicalDecodingContext,
+    options: *mut pg::OutputPluginOptions,
+    _is_init: pg::_bool,
+) {
     use pg::Enum_OutputPluginOutputType::*;
     let last_relid = pg::palloc0(size_of::<pg::Oid>() as u64);
     (*ctx).output_plugin_private = last_relid;
     (*options).output_type = OUTPUT_PLUGIN_TEXTUAL_OUTPUT;
 }
 
-unsafe extern "C" fn begin(ctx: *mut pg::Struct_LogicalDecodingContext,
-                           txn: *mut pg::ReorderBufferTXN) {
+unsafe extern "C" fn begin(
+    ctx: *mut pg::Struct_LogicalDecodingContext,
+    txn: *mut pg::ReorderBufferTXN,
+) {
     let s = CString::new("{ \"begin\": %u }").unwrap();
     pg::OutputPluginPrepareWrite(ctx, CTRUE);
     pg::appendStringInfo((*ctx).out, s.as_ptr(), (*txn).xid);
     pg::OutputPluginWrite(ctx, CTRUE);
 }
 
-unsafe extern "C" fn change(ctx: *mut pg::Struct_LogicalDecodingContext,
-                            _txn: *mut pg::ReorderBufferTXN,
-                            relation: pg::Relation,
-                            change: *mut pg::ReorderBufferChange) {
+unsafe extern "C" fn change(
+    ctx: *mut pg::Struct_LogicalDecodingContext,
+    _txn: *mut pg::ReorderBufferTXN,
+    relation: pg::Relation,
+    change: *mut pg::ReorderBufferChange,
+) {
     let relid = (*relation).rd_id;
     let last_relid: *mut pg::Oid = (*ctx).output_plugin_private as
-                                   *mut pg::Oid;
+        *mut pg::Oid;
     if *last_relid != relid {
         pg::OutputPluginPrepareWrite(ctx, CFALSE);
         append_schema(relation, (*ctx).out);
@@ -59,16 +65,18 @@ unsafe extern "C" fn change(ctx: *mut pg::Struct_LogicalDecodingContext,
     pg::OutputPluginWrite(ctx, CTRUE);
 }
 
-unsafe extern "C" fn commit(ctx: *mut pg::Struct_LogicalDecodingContext,
-                            txn: *mut pg::ReorderBufferTXN,
-                            _lsn: pg::XLogRecPtr) {
+unsafe extern "C" fn commit(
+    ctx: *mut pg::Struct_LogicalDecodingContext,
+    txn: *mut pg::ReorderBufferTXN,
+    _lsn: pg::XLogRecPtr,
+) {
     let s = CString::new("{ \"commit\": %u, \"t\": \"%s\" }").unwrap();
     let t = pg::timestamptz_to_str((*txn).commit_time);
     pg::OutputPluginPrepareWrite(ctx, CTRUE);
     pg::appendStringInfo((*ctx).out, s.as_ptr(), (*txn).xid, t);
     pg::OutputPluginWrite(ctx, CTRUE);
     let last_relid: *mut pg::Oid = (*ctx).output_plugin_private as
-                                   *mut pg::Oid;
+        *mut pg::Oid;
     *last_relid = 0;
 }
 
@@ -140,9 +148,11 @@ impl fmt::Display for Wrapped {
     }
 }
 
-unsafe fn append_change(relation: pg::Relation,
-                        change: *mut pg::ReorderBufferChange,
-                        out: pg::StringInfo) {
+unsafe fn append_change(
+    relation: pg::Relation,
+    change: *mut pg::ReorderBufferChange,
+    out: pg::StringInfo,
+) {
     use pg::Enum_ReorderBufferChangeType::*;
     let relid = (*relation).rd_id;
     let name = pg::get_rel_name(relid);
@@ -159,9 +169,13 @@ unsafe fn append_change(relation: pg::Relation,
         _ => "unrecognized",
     };
     if token == "unrecognized" {
-        log!(format!("Unrecognized Change Action: [ {} ]",
-                     Wrapped((*change).action))
-                 .as_str());
+        log!(
+            format!(
+                "Unrecognized Change Action: [ {} ]",
+                Wrapped((*change).action)
+            )
+            .as_str()
+        );
         return;
     }
     out.add_str("{ ");
@@ -180,9 +194,11 @@ unsafe fn append_change(relation: pg::Relation,
 }
 
 
-unsafe fn append_tuple_buf_as_json(data: *mut pg::ReorderBufferTupleBuf,
-                                   desc: pg::TupleDesc,
-                                   out: pg::StringInfo) {
+unsafe fn append_tuple_buf_as_json(
+    data: *mut pg::ReorderBufferTupleBuf,
+    desc: pg::TupleDesc,
+    out: pg::StringInfo,
+) {
     if !data.is_null() {
         let heap_tuple = &mut (*data).tuple;
         let n = (*desc).natts as usize;
@@ -193,10 +209,12 @@ unsafe fn append_tuple_buf_as_json(data: *mut pg::ReorderBufferTupleBuf,
         let mut nulls: Vec<pg::_bool> = Vec::new();
         datums.resize(n, 0);
         nulls.resize(n, CFALSE);
-        pg::heap_deform_tuple(heap_tuple,
-                              desc,
-                              datums.as_mut_ptr(),
-                              nulls.as_mut_ptr());
+        pg::heap_deform_tuple(
+            heap_tuple,
+            desc,
+            datums.as_mut_ptr(),
+            nulls.as_mut_ptr(),
+        );
 
         let mut skip: Vec<pg::Form_pg_attribute> = Vec::with_capacity(n);
 
@@ -346,9 +364,10 @@ extern "C" fn row_to_json(fcinfo: pg::FunctionCallInfo) -> pg::Datum {
             (((varattrib_1b_e *) (PTR))->va_tag)
 ```
 */
-unsafe fn is_stale_toast(datum: pg::Datum,
-                         attr: pg::Form_pg_attribute)
-                         -> bool {
+unsafe fn is_stale_toast(
+    datum: pg::Datum,
+    attr: pg::Form_pg_attribute,
+) -> bool {
     use pg::Enum_vartag_external::VARTAG_ONDISK;
     let mut o: pg::Oid = 0; // Output function; not used
     let mut is_variable_length: pg::_bool = CFALSE;
@@ -373,8 +392,9 @@ pub unsafe extern "C" fn _PG_init() {}
 
 #[allow(non_snake_case)]
 #[no_mangle]
-pub unsafe extern fn
-_PG_output_plugin_init(cb: *mut pg::OutputPluginCallbacks){
+pub unsafe extern "C" fn _PG_output_plugin_init(
+    cb: *mut pg::OutputPluginCallbacks,
+) {
     init(cb);
 }
 
@@ -386,12 +406,16 @@ const CFALSE: pg::_bool = 0;
 
 pub unsafe fn elog(file: &str, line: u32, function: &str, msg: &str) {
     let level = 15; // The LOG level of logging is normally server-only
-    pg::elog_start(CString::new(file).unwrap().as_ptr(),
-                   line as ::std::os::raw::c_int,
-                   CString::new(function).unwrap().as_ptr());
-    pg::elog_finish(level,
-                    CString::new("%s").unwrap().as_ptr(),
-                    CString::new(msg).unwrap().as_ptr());
+    pg::elog_start(
+        CString::new(file).unwrap().as_ptr(),
+        line as ::std::os::raw::c_int,
+        CString::new(function).unwrap().as_ptr(),
+    );
+    pg::elog_finish(
+        level,
+        CString::new("%s").unwrap().as_ptr(),
+        CString::new(msg).unwrap().as_ptr(),
+    );
 }
 
 pub unsafe fn fmt_name(name: pg::NameData) -> String {

--- a/test/expected/message.out
+++ b/test/expected/message.out
@@ -15,9 +15,9 @@
 
  { "message": "#1", "prefix": "sent first", "transactional": false }
  { "message": "#2", "prefix": "sent third", "transactional": false }
- { "message": "#3", "prefix": "sent last", "transactional": false }
+ { "message": "#3", "prefix": "sent fifth", "transactional": false }
  { "message": "#4", "prefix": "sent fourth", "transactional": true }
- { "message": "#5", "prefix": "{\"hello\" : \"world\"}", "transactional": true }
+ { "message": "{\"hello\" : \"world\"}", "prefix": "sent last", "transactional": true }
 
  deleted logical replication slot
 

--- a/test/expected/message.out
+++ b/test/expected/message.out
@@ -1,0 +1,20 @@
+\set ECHO none
+ created logical replication slot
+
+ visible
+
+ invisible
+
+ non-transactional
+
+ transactional
+
+ non-transactional
+
+ { "message": "#1", "prefix": "sent first", "transactional": false }
+ { "message": "#2", "prefix": "sent third", "transactional": false }
+ { "message": "#3", "prefix": "sent last", "transactional": false }
+ { "message": "#4", "prefix": "sent fourth", "transactional": true }
+
+ deleted logical replication slot
+

--- a/test/expected/message.out
+++ b/test/expected/message.out
@@ -11,10 +11,13 @@
 
  non-transactional
 
+ json
+
  { "message": "#1", "prefix": "sent first", "transactional": false }
  { "message": "#2", "prefix": "sent third", "transactional": false }
  { "message": "#3", "prefix": "sent last", "transactional": false }
  { "message": "#4", "prefix": "sent fourth", "transactional": true }
+ { "message": "#5", "prefix": "{\"hello\" : \"world\"}", "transactional": true }
 
  deleted logical replication slot
 

--- a/test/sql/message.sql
+++ b/test/sql/message.sql
@@ -1,0 +1,36 @@
+\set ECHO none
+SET client_min_messages TO error;
+SET synchronous_commit = on;
+\t on
+\x off
+SELECT 'created logical replication slot'
+  FROM pg_create_logical_replication_slot('jsoncdc', 'jsoncdc');
+
+CREATE SCHEMA IF NOT EXISTS jsoncdc;
+SET LOCAL search_path TO jsoncdc, public;
+
+BEGIN;
+	SELECT 'visible'
+	  FROM pg_logical_emit_message(false, 'sent first', '#1');
+  	SELECT 'invisible'
+	  FROM pg_logical_emit_message(true, 'sent second', 'existence is pain');
+ROLLBACK;
+
+BEGIN;
+	SELECT 'non-transactional'
+	  FROM pg_logical_emit_message(false, 'sent third', '#2');
+	SELECT 'transactional'
+	  FROM pg_logical_emit_message(true, 'sent fourth', '#4');
+  	SELECT 'non-transactional'
+	  FROM pg_logical_emit_message(false, 'sent last', '#3');
+COMMIT;
+
+SELECT *
+  FROM (SELECT data FROM pg_logical_slot_get_changes('jsoncdc', NULL, NULL)) t
+ WHERE data
+  LIKE '{ "message": %';
+
+SELECT 'deleted logical replication slot'
+  FROM pg_drop_replication_slot('jsoncdc');
+
+DROP SCHEMA jsoncdc CASCADE;

--- a/test/sql/message.sql
+++ b/test/sql/message.sql
@@ -22,9 +22,9 @@ BEGIN;
 	SELECT 'transactional'
 	  FROM pg_logical_emit_message(true, 'sent fourth', '#4');
   	SELECT 'non-transactional'
-	  FROM pg_logical_emit_message(false, 'sent last', '#3');
+	  FROM pg_logical_emit_message(false, 'sent fifth', '#3');
 	SELECT 'json'
-	  FROM pg_logical_emit_message(true, json_build_object('hello', 'world')::TEXT, '#5');
+	  FROM pg_logical_emit_message(true, 'sent last', json_build_object('hello', 'world')::TEXT);
 COMMIT;
 
 SELECT *

--- a/test/sql/message.sql
+++ b/test/sql/message.sql
@@ -23,6 +23,8 @@ BEGIN;
 	  FROM pg_logical_emit_message(true, 'sent fourth', '#4');
   	SELECT 'non-transactional'
 	  FROM pg_logical_emit_message(false, 'sent last', '#3');
+	SELECT 'json'
+	  FROM pg_logical_emit_message(true, json_build_object('hello', 'world')::TEXT, '#5');
 COMMIT;
 
 SELECT *

--- a/util/travis
+++ b/util/travis
@@ -33,7 +33,7 @@ EOF
 function linux {
   tools
 
-  VERSION=9.4
+  VERSION=9.6
   PG_DIR=/etc/postgresql/"$VERSION"/main
   HBA_CONF="$PG_DIR"/pg_hba.conf
   CONF="$PG_DIR"/postgresql.conf


### PR DESCRIPTION
**HEADS UP:** This is my first experience with Rust. I couldn't get `rustfmt` to work.

Could I have a hand with reading`message` only up to `length`? (See failed test)

**For discussion:**
- I'm not sure whether it makes sense to emit the `transactional` value, it could have semantic meaning to the application.
- Should `prefix` be sent before `message` to allow for fast filtering on `prefix`?

```
cat regression.diffs 
*** /Users/jmealo/repos2/jsoncdc/test/expected/message.out	2017-08-29 20:26:41.000000000 -0400
--- /Users/jmealo/repos2/jsoncdc/results/message.out	2017-08-29 20:44:03.000000000 -0400
***************
*** 12,19 ****
   non-transactional
  
   { "message": "#1", "prefix": "sent first", "transactional": false }
!  { "message": "#2", "prefix": "sent third", "transactional": false }
!  { "message": "#3", "prefix": "sent last", "transactional": false }
   { "message": "#4", "prefix": "sent fourth", "transactional": true }
  
   deleted logical replication slot
--- 12,19 ----
   non-transactional
  
   { "message": "#1", "prefix": "sent first", "transactional": false }
!  { "message": "#2xistence is pain", "prefix": "sent third", "transactional": false }
!  { "message": "#3#4istence is pain", "prefix": "sent last", "transactional": false }
   { "message": "#4", "prefix": "sent fourth", "transactional": true }
  
   deleted logical replication slot

======================================================================
```